### PR TITLE
Fix for Android Build Issue after RN64 Merge

### DIFF
--- a/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/android-patches/patches/Focus/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -1,6 +1,16 @@
---- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\views\\view\\ReactViewManager.java"	2020-10-27 20:26:16.993188900 -0700
-+++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\views\\view\\ReactViewManager.java"	2020-10-13 21:46:27.236639400 -0700
-@@ -48,8 +48,13 @@
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+index 851ec10c6..4fe93de49 100644
+--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
++++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+@@ -25,6 +25,7 @@ import com.facebook.react.uimanager.PointerEvents;
+ import com.facebook.react.uimanager.Spacing;
+ import com.facebook.react.uimanager.ThemedReactContext;
+ import com.facebook.react.uimanager.UIManagerHelper;
++import com.facebook.react.uimanager.UIManagerModule;
+ import com.facebook.react.uimanager.ViewProps;
+ import com.facebook.react.uimanager.annotations.ReactProp;
+ import com.facebook.react.uimanager.annotations.ReactPropGroup;
+@@ -48,8 +49,13 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
      Spacing.START,
      Spacing.END,
    };
@@ -16,7 +26,7 @@
    private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
  
    @ReactProp(name = "accessible")
-@@ -120,6 +125,36 @@
+@@ -120,6 +126,36 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
      }
    }
  
@@ -53,7 +63,7 @@
    @ReactProp(name = "borderStyle")
    public void setBorderStyle(ReactViewGroup view, @Nullable String borderStyle) {
      view.setBorderStyle(borderStyle);
-@@ -289,7 +324,7 @@
+@@ -287,7 +323,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
  
    @Override
    public Map<String, Integer> getCommandsMap() {
@@ -62,7 +72,7 @@
    }
  
    @Override
-@@ -305,6 +340,16 @@
+@@ -303,6 +339,16 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
            handleSetPressed(root, args);
            break;
          }
@@ -79,7 +89,7 @@
      }
    }
  
-@@ -321,6 +366,16 @@
+@@ -319,6 +365,16 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
            handleSetPressed(root, args);
            break;
          }

--- a/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/android-patches/patches/OfficeRNHost/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1,6 +1,8 @@
---- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManager.java"	2020-10-27 20:26:16.728167300 -0700
-+++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\java\\com\\facebook\\react\\ReactInstanceManager.java"	2020-10-13 21:26:17.779198100 -0700
-@@ -51,6 +51,7 @@
+diff --git a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+index 63ac2ec11..26fee8860 100644
+--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
++++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+@@ -51,6 +51,7 @@ import com.facebook.infer.annotation.ThreadConfined;
  import com.facebook.infer.annotation.ThreadSafe;
  import com.facebook.react.bridge.Arguments;
  import com.facebook.react.bridge.CatalystInstance;
@@ -8,7 +10,7 @@
  import com.facebook.react.bridge.CatalystInstanceImpl;
  import com.facebook.react.bridge.JSBundleLoader;
  import com.facebook.react.bridge.JSIModule;
-@@ -173,6 +174,7 @@
+@@ -173,6 +174,7 @@ public class ReactInstanceManager {
    private final @Nullable NativeModuleCallExceptionHandler mNativeModuleCallExceptionHandler;
    private final @Nullable JSIModulePackage mJSIModulePackage;
    private List<ViewManager> mViewManagers;
@@ -16,7 +18,7 @@
  
    private class ReactContextInitParams {
      private final JavaScriptExecutorFactory mJsExecutorFactory;
-@@ -922,6 +924,15 @@
+@@ -193,6 +195,15 @@ public class ReactInstanceManager {
      }
    }
  
@@ -29,16 +31,16 @@
 +    mCatalystInstanceEventListener = catalystInstanceEventListener;
 +  }
 +
-   /** Add a listener to be notified of react instance events. */
-   public void addReactInstanceEventListener(ReactInstanceEventListener listener) {
-     mReactInstanceEventListeners.add(listener);
-@@ -1245,7 +1256,8 @@
+   /** Creates a builder that is capable of creating an instance of {@link ReactInstanceManager}. */
+   public static ReactInstanceManagerBuilder builder() {
+     return new ReactInstanceManagerBuilder();
+@@ -1266,7 +1277,8 @@ public class ReactInstanceManager {
              .setJSExecutor(jsExecutor)
              .setRegistry(nativeModuleRegistry)
              .setJSBundleLoader(jsBundleLoader)
 -            .setNativeModuleCallExceptionHandler(exceptionHandler);
 +            .setNativeModuleCallExceptionHandler(exceptionHandler)
-+            .setCatalystInstanceEventListener(mCatalystInstanceEventListener);
++	    .setCatalystInstanceEventListener(mCatalystInstanceEventListener);
  
      ReactMarker.logMarker(CREATE_CATALYST_INSTANCE_START);
      // CREATE_CATALYST_INSTANCE_END is in JSCExecutor.cpp

--- a/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/android-patches/patches/V8/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -1,16 +1,17 @@
---- "E:\\github\\rnm-63-fresh\\ReactAndroid\\src\\main\\jni\\react\\jni\\Android.mk"	2020-10-27 20:26:17.023172300 -0700
-+++ "E:\\github\\rnm-63\\ReactAndroid\\src\\main\\jni\\react\\jni\\Android.mk"	2020-10-13 21:47:10.404176500 -0700
-@@ -71,6 +71,7 @@
- $(call import-module,callinvoker)
+diff --git a/ReactAndroid/src/main/jni/react/jni/Android.mk b/ReactAndroid/src/main/jni/react/jni/Android.mk
+index 38a51019e..7425e65a5 100644
+--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
++++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
+@@ -72,6 +72,7 @@ $(call import-module,callinvoker)
+ $(call import-module,reactperflogger)
  $(call import-module,hermes)
  $(call import-module,runtimeexecutor)
 +$(call import-module,v8jsi)
  
  include $(REACT_SRC_DIR)/turbomodule/core/jni/Android.mk
  
-@@ -82,3 +83,4 @@
+@@ -83,3 +84,4 @@ include $(REACT_SRC_DIR)/jscexecutor/Android.mk
  include $(REACT_SRC_DIR)/../hermes/reactexecutor/Android.mk
  include $(REACT_SRC_DIR)/../hermes/instrumentation/Android.mk
  include $(REACT_SRC_DIR)/modules/blob/jni/Android.mk
 +include $(REACT_SRC_DIR)/v8executor/Android.mk
-\ No newline at end of file


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ * ] I am making a change required for Microsoft usage of react-native

## Summary

Fix the build issues in Android after the RN64 merge

